### PR TITLE
fix(RATP-1638): update CODEOWNERS - replace ratp with ntc

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @doctolib/ratp
+* @doctolib/ntc
 
 # Needed for renovate automatic merge mechanism
-Gemfile.lock @doctolib/deployment @doctolib/ratp
+Gemfile.lock @doctolib/deployment @doctolib/ntc


### PR DESCRIPTION
## Summary
- Replace `@doctolib/ratp` with `@doctolib/ntc` in all CODEOWNERS entries
- Aligns with ownership change in [github-workspaces#4908](https://github.com/doctolib/github-workspaces/pull/4908)

## Test plan
- [ ] Verify CODEOWNERS syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)