### PR TITLE
fix(RATP-1650): correct renovate preset path for schedule-doctolib-weekly-on-sunday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>doctolib/renovate-config",
-    "local>doctolib/renovate-config:schedule-doctolib-weekly-on-sunday"
+    "local>doctolib/renovate-config//presets/schedule-doctolib-weekly-on-sunday.json5"
   ],
   "automerge": true,
   "enabledManagers": [


### PR DESCRIPTION
## Summary
- Fix broken Renovate configuration that was blocking all PRs
- The preset reference `local>doctolib/renovate-config:schedule-doctolib-weekly-on-sunday` uses colon syntax which resolves to a root-level file, but the preset lives at `presets/schedule-doctolib-weekly-on-sunday.json5`
- Changed to `local>doctolib/renovate-config//presets/schedule-doctolib-weekly-on-sunday.json5` using the `//` path syntax, matching how `doctolib/renovate-config` references its own presets internally

## Test plan
- [ ] Verify Renovate no longer reports a configuration error
- [ ] Confirm Renovate resumes creating PRs on the next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)